### PR TITLE
feat: use DynamoDB to handle multiple function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ slack:
 secret_version_id: ""
 # change_password, ignore, error
 when_login_profile_exist: change_password
+dynamodb_table_name: aws-iam-cred-sender
 ```
 
 Required
@@ -92,11 +93,24 @@ Template variables:
 * secretsmanager:GetSecretValue
 * iam:CreateLoginProfile
 * iam:UpdateLoginProfile
+* dynamodb:GetItem
+* dynamodb:UpdateItem
 
 ### Slack App Permission
 
 * chat:write (chat.postMessage)
 * users:read (users.list)
+
+## Handle multiple function call with DynamoDB
+
+[#12](https://github.com/suzuki-shunsuke/aws-iam-cred-sender/pull/12)
+
+Sometimes Lambda Function is called at multiple times by CloudWatch Event.
+
+https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CWE_Troubleshooting.html#RuleTriggeredMoreThanOnce
+
+So we use DynamoDB to handle multiple function call.
+The function registers the User Name at DynamoDB, and if the User Name is already registered at DynamoDB table the function aborts the request.
 
 ## LICENSE
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Slack                 SlackConfig
 	InitialPasswordLength int    `yaml:"initial_password_length"`
 	WhenLoginProfileExist string `yaml:"when_login_profile_exist"`
+	DynamoDBTableName     string `yaml:"dynamodb_table_name"`
 }
 
 type SlackConfig struct {

--- a/pkg/controller/dynamodb.go
+++ b/pkg/controller/dynamodb.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+func (ctrl *Controller) existUserNameAtDynamoDB(ctx context.Context, svc *dynamodb.DynamoDB, userName string) (bool, error) {
+	result, err := svc.GetItemWithContext(ctx, &dynamodb.GetItemInput{
+		Key: map[string]*dynamodb.AttributeValue{
+			"UserName": {
+				S: aws.String(userName),
+			},
+		},
+		TableName: aws.String(ctrl.Config.DynamoDBTableName),
+	})
+	if err != nil {
+		return false, fmt.Errorf("get an item from DynamoDB: %w", err)
+	}
+	return len(result.Item) != 0, nil
+}
+
+func (ctrl *Controller) addUserNameToDynamoDB(ctx context.Context, svc *dynamodb.DynamoDB, userName string) error {
+	if _, err := svc.UpdateItemWithContext(ctx, &dynamodb.UpdateItemInput{
+		Key: map[string]*dynamodb.AttributeValue{
+			"UserName": {
+				S: aws.String(userName),
+			},
+		},
+		TableName: aws.String(ctrl.Config.DynamoDBTableName),
+	}); err != nil {
+		return fmt.Errorf("update an item of DynamoDB: %w", err)
+	}
+	return nil
+}

--- a/pkg/lambda/handler.go
+++ b/pkg/lambda/handler.go
@@ -70,6 +70,9 @@ func (handler *Handler) setDefaultConfig(cfg *controller.Config) {
 	if cfg.WhenLoginProfileExist == "" {
 		cfg.WhenLoginProfileExist = "change_password"
 	}
+	if cfg.DynamoDBTableName == "" {
+		cfg.DynamoDBTableName = "aws-iam-cred-sender"
+	}
 }
 
 func (handler *Handler) Init(ctx context.Context) error {


### PR DESCRIPTION
Sometimes Lambda Function is called at multiple times by CloudWatch Event.

https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CWE_Troubleshooting.html#RuleTriggeredMoreThanOnce

So we use DynamoDB to handle multiple function call.
The function registers the User Name at DynamoDB, and if the User Name is already registered at DynamoDB table the function aborts the request.

